### PR TITLE
modify uestc.bst to handle references without optional field

### DIFF
--- a/thesis-uestc.bst
+++ b/thesis-uestc.bst
@@ -442,17 +442,18 @@ FUNCTION {article}
     format.authors write$ add.period
     format.title "[J]" * write$ add.period
     format.journal write$ add.comma
-    format.year write$ add.comma
-    
+    format.year write$
+
     number missing$
     {
-        volume ": " * write$
+    
     } {
+        add.comma
         volume "(" *
         number *
-        "): " * write$
+        "): " *
+        pages * write$
     } if$
-    format.pages write$
     newline$
 }
 


### PR DESCRIPTION
handle references without optional field

related issues:
[109](https://github.com/x-magus/ThesisUESTC/issues/109)
[102](https://github.com/x-magus/ThesisUESTC/issues/102)