### PR TITLE
Add the reference format for online computer program

### DIFF
--- a/thesis-uestc.bst
+++ b/thesis-uestc.bst
@@ -567,6 +567,16 @@ FUNCTION {onlynote}
     newline$
 }
 
+FUNCTION {onlineprogram}
+{
+    bibitem.begin
+    format.authors write$ add.period
+    format.title "[CP/OL]" * write$ add.period
+    format.url write$ add.comma
+    format.year write$
+    newline$
+}
+
 READ
 
 EXECUTE {bib.begin}


### PR DESCRIPTION
Online computer programs are very common references nowdays, especially due to the movement of free software and open source software.
However, I did not find the function that defines the format for online computer programs.
Therefore, I add this function according to the format definition in 《电 子 科 技 大 学研究生学位论文（研究报告）撰写格式规范》as shown in the following,
```
（1）文献类型标志
①参考文献类型：期刊文章[J]，会议论文[C]，专著[M]，学位论文[D]，报纸文章[N]，报告[R]，专利[P]，标准[S]；
②电子文献类型：数据库[DB]，计算机程序[CP]，电子公告[EB]；
③电子文献的载体类型：互联网[OL]，光盘[CD]，磁带[MT]，磁盘[DK]。
```
```
电子文献：[序号] 作者.文题[文献类型标志/文献载体标志]. 出版地或获得地址：出版者，发表更新日期或引用日期
```
```
M. Clerc. Discrete particle swarm optimization: a fuzzy combinatorial box[EB/OL]. http://clere.maurice.free.fr/pso/Fuzzy_Discrere_PSO/Fuzzy_DPSO.htm, July 16, 2010
```