### PR TITLE
Fix proof environment

### DIFF
--- a/thesis-uestc.cls
+++ b/thesis-uestc.cls
@@ -1095,9 +1095,15 @@ School: & \en@theschool \\
   \normalfont
   \topsep0pt \partopsep0pt
   \trivlist
-  \item[\hskip5\labelsep
+  \item[\hskip4.5\labelsep
     \strong
-  #1\@addpunct{:}]\ignorespaces
+    \ifchinesebook{%
+      #1\@addpunct{\chinesecolon}}{
+      #1\@addpunct{:}
+    }
+    ]\ignorespaces
+  \hfill
+  \par
 }{
   \popQED\endtrivlist\@endpefalse
 }


### PR DESCRIPTION
Modify the proof environment according to the latest standard

According to the latest 《研究生学位论文（含研究报告）撰写格式规范/研究生学位论文（含研究报告）撰写范例（中文）》，we did the following modifications in this commit.

1. Start a new paragraph after `证明：`。
2. Use `\chinesecolon` after `证明` if in Chinese mode。
3. Adjust the indentation of `证明：`。

**Figure 1. Example from the 撰写范例**
![Example from the standard](https://user-images.githubusercontent.com/10540480/116644452-f892cb80-a9a5-11eb-8e80-774007e30099.png)
**Figure 2. Example with the commit**
![Example with the commit](https://user-images.githubusercontent.com/10540480/116644571-50c9cd80-a9a6-11eb-8ef7-75f98c77f498.png)
**Figure 3. Example without the commit**
![Example without the commit](https://user-images.githubusercontent.com/10540480/116644829-fb41f080-a9a6-11eb-8305-daff1c12275a.png)

