### PR TITLE
按2022新标修正参考文献格式;修封面及正文页眉格式。

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -9,23 +9,27 @@
 \school{物理电子学院}{School of Physical Electronics}
 \major{无线电物理}{Radio Physics}
 \studentnumber{201421040223}
+% \ProfessionalDegreeArea{} % 仅用于设置专业学位领域
+\ClassificationNumber{TP309.2} % 分类号
+\ClassifiedClass{公开} % 密级
+\UDCNumber{004.78} % UDC编号
 
 \begin{document}
 
 \makecover
 
 \begin{chineseabstract}
-为了适应日益增长的宽带信号和非线性系统的工程应用，用于分析瞬态电磁散射问题的时域积分方程方法研究日趋活跃。本文以时域积分方程时间步进算法及其快速算法为研究课题，重点研究了时间步进算法的数值实现技术、后时稳定性问题以及两层平面波算法加速计算等，主要研究内容分为四部分。
+    为了适应日益增长的宽带信号和非线性系统的工程应用，用于分析瞬态电磁散射问题的时域积分方程方法研究日趋活跃。本文以时域积分方程时间步进算法及其快速算法为研究课题，重点研究了时间步进算法的数值实现技术、后时稳定性问题以及两层平面波算法加速计算等，主要研究内容分为四部分。
 
-……
+    ……
 
-\chinesekeyword{时域电磁散射，时域积分方程，时间步进算法，后时不稳定性，时域平面波算法}
+    \chinesekeyword{时域电磁散射，时域积分方程，时间步进算法，后时不稳定性，时域平面波算法}
 \end{chineseabstract}
 
 \begin{englishabstract}
-With the widespread engineering applications ranging from broadband signals and non-linear systems, time-domain integral equations (TDIE) methods for analyzing transient electromagnetic scattering problems are becoming widely used nowadays. TDIE-based marching-on-in-time (MOT) scheme and its fast algorithm are researched in this dissertation, including the numerical techniques of MOT scheme, late-time stability of MOT scheme, and two-level PWTD-enhanced MOT scheme. The contents are divided into four parts shown as follows.
+    With the widespread engineering applications ranging from broadband signals and non-linear systems, time-domain integral equations (TDIE) methods for analyzing transient electromagnetic scattering problems are becoming widely used nowadays. TDIE-based marching-on-in-time (MOT) scheme and its fast algorithm are researched in this dissertation, including the numerical techniques of MOT scheme, late-time stability of MOT scheme, and two-level PWTD-enhanced MOT scheme. The contents are divided into four parts shown as follows.
 
-\englishkeyword{Time-domain Electromagnetic Scattering, Time-domain Integral Equation, Marching-on In-time (MOT) Scheme, Late-time Instability, Plane Wave Time-domain (PWTD) Algorithm}
+    \englishkeyword{Time-domain Electromagnetic Scattering, Time-domain Integral Equation, Marching-on In-time (MOT) Scheme, Late-time Instability, Plane Wave Time-domain (PWTD) Algorithm}
 \end{englishabstract}
 
 \thesistableofcontents
@@ -56,31 +60,31 @@ With the widespread engineering applications ranging from broadband signals and 
 \subsection{空间基函数}
 RWG 基函数是定义在三角形单元上的最具代表性的基函数。它的具体定义如下：
 \begin{equation}
-f_n(\bm{r})=
-\begin{cases}
-\frac{l_n}{2A_n^+}\bm{\rho}_n^+=\frac{l_n}{2A_n^+}(\bm{r}-\bm{r}_+)&\bm{r}\in T_n^+\\
-\frac{l_n}{2A_n^-}\bm{\rho}_n^-=\frac{l_n}{2A_n^-}(\bm{r}_--\bm{r})&\bm{r}\in T_n^-\\
-0&\text{otherwise}
-\end{cases}
+    f_n(\bm{r})=
+    \begin{cases}
+        \frac{l_n}{2A_n^+}\bm{\rho}_n^+=\frac{l_n}{2A_n^+}(\bm{r}-\bm{r}_+) & \bm{r}\in T_n^+  \\
+        \frac{l_n}{2A_n^-}\bm{\rho}_n^-=\frac{l_n}{2A_n^-}(\bm{r}_--\bm{r}) & \bm{r}\in T_n^-  \\
+        0                                                                   & \text{otherwise}
+    \end{cases}
 \end{equation}
 
 其中，$l_n$为三角形单元$T_n^+$和$T_n^-$公共边的长度，$A_n^+$和$A_n^-$分别为三角形单元$T_n^+$和$T_n^-$的面积（如图\ref{pica}所示）。
 
 \begin{figure}[h]
-\includegraphics{pica.pdf}
-\caption{RWG 基函数几何参数示意图}
-\label{pica}
+    \includegraphics{pica.pdf}
+    \caption{RWG 基函数几何参数示意图}
+    \label{pica}
 \end{figure}
 
 由于时域混合场积分方程是时域电场积分方程与时域磁场积分方程的线性组合，因此时域混合场积分方程时间步进算法的阻抗矩阵特征与时域电场积分方程时间步进算法的阻抗矩阵特征相同。
 \begin{equation}
-\label{latent_binary_variable}
-\bm{r}_{i,j}=
-\begin{cases}
-1,f(\bm{x}^{i};\bm{w})\cdot f(\bm{x}^{j};\bm{w})\geq u(\lambda),\\
-0,f(\bm{x}^{i};\bm{w})\cdot f(\bm{x}^{j};\bm{w})< l(\lambda), 1\leq i,j\leq n.\\
-f(\bm{x}^{i};\bm{w})\cdot f(\bm{x}^{j};\bm{w}),\text{otherwise},
-\end{cases}
+    \label{latent_binary_variable}
+    \bm{r}_{i,j}=
+    \begin{cases}
+        1,f(\bm{x}^{i};\bm{w})\cdot f(\bm{x}^{j};\bm{w})\geq u(\lambda),               \\
+        0,f(\bm{x}^{i};\bm{w})\cdot f(\bm{x}^{j};\bm{w})< l(\lambda), 1\leq i,j\leq n. \\
+        f(\bm{x}^{i};\bm{w})\cdot f(\bm{x}^{j};\bm{w}),\text{otherwise},
+    \end{cases}
 \end{equation}
 
 时域积分方程时间步进算法的阻抗元素直接影响算法的后时稳定性，因此阻抗元素的计算是算法的关键之一，采用精度高效的方法计算时域阻抗元素是时域积分方程时间步进算法研究的重点之一。
@@ -97,16 +101,16 @@ f(\bm{x}^{i};\bm{w})\cdot f(\bm{x}^{j};\bm{w}),\text{otherwise},
 如图\ref{picb}和图\ref{picc}所示分别给出了参数$E_0=\hat{x}$，$a_n=-\hat{z}$，$f_0=250MHz$，$f_w=50MHz$，$t_w=4.2\sigma$时，调制高斯脉冲的时域与频域归一化波形图。
 
 \begin{figure}[h]
-\subfloat[]{
-    \label{picb}
-    \includegraphics[width=7.3cm]{picb.pdf}
-}
-\subfloat[]{
-    \label{picc}
-    \includegraphics[width=6.41cm]{picc.pdf}
-}
-\caption{调制高斯脉冲时域与频率波形，时域阻抗元素的存储技术也是时间步进算法并行化的关键技术之一。(a)调制高斯脉冲信号的时域波形；(b)调制高斯脉冲信号的频域波形}
-\label{fig1}
+    \subfloat[]{
+        \label{picb}
+        \includegraphics[width=7.3cm]{picb.pdf}
+    }
+    \subfloat[]{
+        \label{picc}
+        \includegraphics[width=6.41cm]{picc.pdf}
+    }
+    \caption{调制高斯脉冲时域与频率波形，时域阻抗元素的存储技术也是时间步进算法并行化的关键技术之一。(a)调制高斯脉冲信号的时域波形；(b)调制高斯脉冲信号的频域波形}
+    \label{fig1}
 \end{figure}
 
 时域阻抗元素的存储技术\citing{xiao2012yi}也是时间步进算法并行化的关键技术之一，采用合适的阻抗元素存储方式可以很大的提高并行时间步进算法的计算效率。
@@ -162,50 +166,50 @@ f(\bm{x}^{i};\bm{w})\cdot f(\bm{x}^{j};\bm{w}),\text{otherwise},
 方式的存储量大小。
 
 \begin{table}[h]
-\caption{计算$2m\times 2m$理想导体平板时域感应电流采用的三种存储方式的存储量比较。}
-\begin{tabular}{cccc}
-\toprule
-\multirow{2}{*}{时间步长} & \multicolumn{3}{c}{存储方式} \\
-\cmidrule{2-4}
-& 非压缩存储方式 & 完全压缩存储方式 & 基权函数压缩存储方式 \\
-\midrule
-0.4ns & 5.59 MB & 6.78 MB & 6.78 MB\\
-0.5ns & 10.17 MB & 5.58 MB & 5.58 MB \\
-0.6ns & 8.38MB & 4.98 MB & 4.98 MB \\
-\bottomrule
-\end{tabular}
-\label{tablea}
+    \caption{计算$2m\times 2m$理想导体平板时域感应电流采用的三种存储方式的存储量比较。}
+    \begin{tabular}{cccc}
+        \toprule
+        \multirow{2}{*}{时间步长} & \multicolumn{3}{c}{存储方式}                                           \\
+        \cmidrule{2-4}
+                                  & 非压缩存储方式               & 完全压缩存储方式 & 基权函数压缩存储方式 \\
+        \midrule
+        0.4ns                     & 5.59 MB                      & 6.78 MB          & 6.78 MB              \\
+        0.5ns                     & 10.17 MB                     & 5.58 MB          & 5.58 MB              \\
+        0.6ns                     & 8.38MB                       & 4.98 MB          & 4.98 MB              \\
+        \bottomrule
+    \end{tabular}
+    \label{tablea}
 \end{table}
 
 如图\ref{picd}所示给出了时间步长选取为0.5ns 时采用三种不同存储方式计算的平板中心处$x$方向的感应电流值与IDFT 方法计算结果的比较，……。如图\ref{pice}所示给出了存储方式为基权函数压缩存储方式，时间步长分别取0.4ns、0.5ns、0.6ns时平板中心处$x$方向的感应电流计算结果，从图中可以看出不同时间步长的计算结果基本相同。
 
 \begin{figure}[h]
-\subfloat[]{
-    \label{picd}
-    \includegraphics[width=6.77cm]{picd.pdf}
-}
-\subfloat[]{
-    \label{pice}
-    \includegraphics[width=7.04cm]{pice.pdf}
-}
-\caption{$2m\times 2m$的理想导体平板中心处感应电流$x$分量随时间的变化关系。(a)不同存储方式的计算结果与IDFT方法的结果比较；(b)不同时间步长的计算结果比较比较比较}
-\label{fig2}
+    \subfloat[]{
+        \label{picd}
+        \includegraphics[width=6.77cm]{picd.pdf}
+    }
+    \subfloat[]{
+        \label{pice}
+        \includegraphics[width=7.04cm]{pice.pdf}
+    }
+    \caption{$2m\times 2m$的理想导体平板中心处感应电流$x$分量随时间的变化关系。(a)不同存储方式的计算结果与IDFT方法的结果比较；(b)不同时间步长的计算结果比较比较比较}
+    \label{fig2}
 \end{figure}
 
 由于时域混合场积分方程是时域电场积分方程与时域磁场积分方程的线性组合，因此时域混合场积分方程时间步进算法的阻抗矩阵特征与时域电场积分方程时间步进算法的阻抗矩阵特征相同。
 
 \section{时域积分方程时间步进算法矩阵方程的求解}
 \begin{theorem}
-如果时域混合场积分方程是时域电场积分方程与时域磁场积分方程的线性组合。
+    如果时域混合场积分方程是时域电场积分方程与时域磁场积分方程的线性组合。
 \end{theorem}
 \begin{proof}
-由于时域混合场积分方程是时域电场积分方程与时域磁场积分方程的线性组合，因此时域混合场积分方程时间步进算法的阻抗矩阵特征与时域电场积分方程时间步进算法的阻抗矩阵特征相同。
+    由于时域混合场积分方程是时域电场积分方程与时域磁场积分方程的线性组合，因此时域混合场积分方程时间步进算法的阻抗矩阵特征与时域电场积分方程时间步进算法的阻抗矩阵特征相同。
 \end{proof}
 \begin{corollary}
-时域积分方程方法的研究近几年发展迅速，在本文研究工作的基础上，仍有以下方向值得进一步研究。
+    时域积分方程方法的研究近几年发展迅速，在本文研究工作的基础上，仍有以下方向值得进一步研究。
 \end{corollary}
 \begin{lemma}
-因此时域混合场积分方程时间步进算法的阻抗矩阵特征与时域电场积分方程时间步进算法的阻抗矩阵特征相同。
+    因此时域混合场积分方程时间步进算法的阻抗矩阵特征与时域电场积分方程时间步进算法的阻抗矩阵特征相同。
 \end{lemma}
 
 \section{本章小结}

--- a/reference.bib
+++ b/reference.bib
@@ -1,78 +1,77 @@
 
-@article{wang1999sanwei,
-  title = {三维矢量散射积分方程中奇异性分析},
-  author = {王浩刚 and 聂在平},
-  journal = {电子学报},
-  volume = {27},
-  number = {12},
-  pages = {68 -- 71},
-  year = {1999}
-}
-
-@conference{liuxf2006,
-  author = {Liu, X F and Wang, Bing Zhong and Shao, Wei and Wen Wang},
-  title = {A marching-on-in-order scheme for exact attenuation constant extraction of lossy transmission lines},
-  year = {2006},
-  pages = {527-529},
-  address = {Chengdu},
-  booktitle = {China-Japan Joint Microwave Conference Proceedings}
-}
-
-@book{zhu1973wulixue,
-  title = {物理学},
-  author = {竺可桢},
-  year = {1973},
-  address = {北京},
-  pages = {56-60},
-  publisher = {科学出版社}
-}
-
 @thesis{chen2001hao,
-  author = {陈念永},
-  title = {毫米波细胞生物效应及抗肿瘤研究},
-  institution = {电子科技大学},
-  year = {2001},
-  pages = {50-60},
-  address = {成都}
-}
-
-@newspaper{gu2012lao,
-  author = {顾春},
-  title = {牢牢把握稳中求进的总基调},
-  journal = {人民日报},
-  date = {2012年3月31日}
-}
-
-@techreport{feng997he,
-  author = {冯西桥},
-  title = {核反应堆压力容器的{LBB}分析},
-  institution = {清华大学核能技术设计研究院},
-  date = {1997年6月25日},
-  address = {北京}
-}
-
-@patent{xiao2012yi,
-  author = {肖珍新},
-  title = {一种新型排渣阀调节降温装置},
-  date = {2012年4月25日},
-  type = {实用新型专利},
-  country = {中国},
-  id = {ZL201120085830.0}
-}
-
-@standard{zhong1994zhong,
-  institution = {中华人民共和国国家技术监督局},
-  id = {GB3100-3102},
-  title = {中华人民共和国国家标准--量与单位},
-  publisher = {中国标准出版社},
-  date = {1994年11月1日},
-  address = {北京}
+    address     = {成都},
+    author      = {陈念永},
+    institution = {电子科技大学},
+    pages       = {50-60},
+    title       = {毫米波细胞生物效应及抗肿瘤研究},
+    year        = {2001}
 }
 
 @digital{clerc2010discrete,
-  author = {M. Clerc},
-  title = {Discrete particle swarm optimization: a fuzzy combinatorial box},
-  type = {EB/OL},
-  date = {July 16, 2010},
-  url = {http://clere.maurice.free.fr/pso/Fuzzy_Discrere_PSO/Fuzzy_DPSO.htm}
+    author = {M. Clerc},
+    date   = {July 16, 2010},
+    title  = {Discrete particle swarm optimization: a fuzzy combinatorial box},
+    type   = {EB/OL},
+    url    = {http://clere.maurice.free.fr/pso/Fuzzy_Discrere_PSO/Fuzzy_DPSO.htm}
+}
+
+@techreport{feng997he,
+    address     = {北京},
+    author      = {冯西桥},
+    date        = {1997-06-25},
+    institution = {清华大学核能技术设计研究院},
+    title       = {核反应堆压力容器的{LBB}分析}
+}
+
+@newspaper{gu2012lao,
+    author  = {顾春},
+    date    = {2012-03-31},
+    journal = {人民日报},
+    title   = {牢牢把握稳中求进的总基调}
+}
+
+@conference{liuxf2006,
+    address   = {Chengdu},
+    author    = {Liu, X F and Wang, Bing Zhong and Shao, Wei and Wen Wang},
+    booktitle = {China-Japan Joint Microwave Conference Proceedings},
+    pages     = {527-529},
+    title     = {A marching-on-in-order scheme for exact attenuation constant extraction of lossy transmission lines},
+    year      = {2006}
+}
+
+@article{wang1999sanwei,
+    author  = {王浩刚 and 聂在平},
+    journal = {电子学报},
+    number  = {12},
+    pages   = {68 -- 71},
+    title   = {三维矢量散射积分方程中奇异性分析},
+    volume  = {27},
+    year    = {1999}
+}
+
+@patent{xiao2012yi,
+    author = {肖珍新},
+    date   = {2012-04-25},
+    id     = {ZL201120085830.0},
+    title  = {一种新型排渣阀调节降温装置},
+    type   = {实用新型专利}
+}
+
+@standard{zhong1994zhong,
+    address     = {北京},
+    id          = {GB3100-3102},
+    institution = {中华人民共和国国家技术监督局},
+    publisher   = {中国标准出版社},
+    title       = {中华人民共和国国家标准--量与单位},
+    year        = {1994}
+}
+
+@book{zhu1973wulixue,
+    address   = {北京},
+    author    = {竺可桢},
+    pages     = {56-60},
+    publisher = {科学出版社},
+    title     = {物理学},
+    year      = {1973}
 }

--- a/thesis-uestc.bst
+++ b/thesis-uestc.bst
@@ -159,6 +159,26 @@ INTEGERS { nameptr namesleft numnames }
 
 STRINGS  { bibinfo}
 
+STRINGS {z}
+FUNCTION {remove.dots}
+{ 'z :=
+   ""
+   { z empty$ not }
+   { z #1 #2 substring$
+     duplicate$ "\." =
+       { z #3 global.max$ substring$ 'z :=  * }
+       { pop$
+         z #1 #1 substring$
+         z #2 global.max$ substring$ 'z :=
+         duplicate$ "." = 'pop$
+           { * }
+         if$
+       }
+     if$
+   }
+   while$
+}
+
 FUNCTION {format.names}
 { 'bibinfo :=
   duplicate$ empty$ 'skip$ {
@@ -169,8 +189,9 @@ FUNCTION {format.names}
   numnames 'namesleft :=
     { namesleft #0 > }
     { s nameptr
-      "{f.~}{vv~}{ll}{, jj}"
+      "{vv~}{ll}{ f{~}}{ jj}"
       format.name$
+      remove.dots
       bibinfo bibinfo.check
       't :=
       nameptr #1 >
@@ -219,7 +240,7 @@ FUNCTION {format.chinese.names}
   numnames 'namesleft :=
     { namesleft #0 > }
     { s nameptr
-      "{f.~}{vv~}{ll}{, jj}"
+      "{vv~}{ll}{, jj}{f{ }}"
       format.name$
       % bibinfo bibinfo.check
       't :=
@@ -244,6 +265,7 @@ FUNCTION {format.chinese.names}
               'skip$
               { "," * }
               if$
+              "," *
               t "others" =
                 {
                   " " * bbl.deng *
@@ -401,6 +423,7 @@ FUNCTION {book}
         add.comma
         format.pages write$
     } if$
+    add.period
     newline$
 }
 
@@ -420,15 +443,20 @@ FUNCTION {conference}
     } {
         format.journal write$
     } if$
-
     add.comma
     address missing$
     'skip$
     {
         format.address write$ add.comma
     } if$
-    format.year write$ add.comma
-    format.pages write$
+    format.year write$
+    pages missing$
+    'skip$
+    {
+        ": " write$
+        format.pages write$
+    } if$
+    add.period
     newline$
 }
 
@@ -449,7 +477,6 @@ FUNCTION {article}
     format.title "[J]" * write$ add.period
     format.journal write$ add.comma
     format.year write$
-    
     volume missing$ {
       pages missing$ 'skip$
       {
@@ -465,6 +492,7 @@ FUNCTION {article}
       } if$
       pages missing$ 'skip$ { ": " format.pages * write$ } if$
     } if$
+    add.period
     newline$
 }
 
@@ -479,8 +507,14 @@ FUNCTION {thesis}
         format.address write$ ": " write$
     } if$
     format.institution write$ add.comma
-    format.year write$ add.comma
-    format.pages write$
+    format.year write$
+    pages missing$
+    'skip$
+    {
+        add.comma
+        format.pages write$
+    } if$
+    add.period
     newline$
 }
 
@@ -506,8 +540,8 @@ FUNCTION {newspaper}
         format.journal write$
     } if$
     add.comma
-
     format.date write$
+    add.period
     newline$
 }
 
@@ -523,6 +557,7 @@ FUNCTION {techreport}
     } if$
     format.institution write$ add.comma
     format.date write$
+    add.period
     newline$
 }
 
@@ -530,11 +565,10 @@ FUNCTION {patent}
 {
     bibitem.begin
     format.authors write$ add.period
-    format.title "[P]" * write$ add.period
-    format.country write$ add.comma
-    format.type write$ add.comma
-    format.id write$ add.comma
+    format.title write$ ": " write$
+    format.id write$ "[P]" * write$ add.period
     format.date write$
+    add.period
     newline$
 }
 
@@ -542,22 +576,38 @@ FUNCTION {standard}
 {
     bibitem.begin
     format.institution write$ add.period
-    format.id write$ add.period
-    format.title "[S]" * write$ add.period
+    format.title write$ ": " write$
+    format.id write$ "[S]" * write$ add.period
     format.address write$ ": " write$
     format.publisher write$ add.comma
-    format.date write$
+    format.year write$
+    pages missing$
+    'skip$
+    {
+        ": " write$
+        format.pages write$
+    } if$
+    add.period
     newline$
 }
 
 FUNCTION {digital}
 {
     bibitem.begin
-    format.authors write$ add.period
+    format.authors missing$
+    'skip$
+    {
+        format.authors write$ add.period
+    } if$
     format.title write$
     "[" format.type * "]" * write$ add.period
-    format.date write$ add.comma
+    format.date missing$
+    'skip$
+    {
+        format.date write$ add.comma
+    } if$
     format.url write$
+    add.period
     newline$
 }
 
@@ -568,8 +618,10 @@ FUNCTION {misc}
     format.title write$
     "[J]. CoRR abs/" eprint * write$ add.comma
     format.year write$
+    add.period
     newline$
 }
+
 
 FUNCTION {onlynote}
 {

--- a/thesis-uestc.bst
+++ b/thesis-uestc.bst
@@ -566,7 +566,7 @@ FUNCTION {patent}
     bibitem.begin
     format.authors write$ add.period
     format.title write$ ": " write$
-    format.id write$ "[P]" * write$ add.period
+    format.id "[P]" * write$ add.period
     format.date write$
     add.period
     newline$
@@ -577,7 +577,7 @@ FUNCTION {standard}
     bibitem.begin
     format.institution write$ add.period
     format.title write$ ": " write$
-    format.id write$ "[S]" * write$ add.period
+    format.id "[S]" * write$ add.period
     format.address write$ ": " write$
     format.publisher write$ add.comma
     format.year write$

--- a/thesis-uestc.cls
+++ b/thesis-uestc.cls
@@ -36,6 +36,7 @@
 \setlength{\cmidrulewidth}{0.5pt}
 
 \RequirePackage{setspace}
+\RequirePackage{adjustbox}
 \RequirePackage{multirow}
 \RequirePackage[tbtags]{amsmath}
 \RequirePackage{amssymb}
@@ -43,7 +44,7 @@
 \RequirePackage{lmodern}
 \RequirePackage[nopostdot]{glossaries}
 \RequirePackage{mathspec}
-
+\RequirePackage{enumerate}
 \RequirePackage{xeCJK}
 \RequirePackage{ifplatform}
 
@@ -134,6 +135,7 @@
 \setlength{\headheight}{15pt}
 
 \pagestyle{fancy}
+\renewcommand{\headrulewidth}{0.75pt}
 \linespread{1.391}
 \setlength\parindent{24pt}
 \titlespacing{\chapter}{0pt}{0pt}{18pt}
@@ -353,6 +355,10 @@
 \newcommand{\en@theadvisor}{\chinesespace}
 
 \newcommand{\thestudentnumber}{\chinesespace}
+\newcommand{\theClassificationNumber}{\chinesespace}
+\newcommand{\theClassifiedClass}{\chinesespace}
+\newcommand{\theUDCNumber}{\chinesespace}
+\newcommand{\theProfessionalDegreeArea}{\chinesespace}
 
 \renewcommand{\title}[2]{
   \renewcommand{\zh@thetitle}{#1}
@@ -386,6 +392,22 @@
 
 \newcommand{\studentnumber}[1]{
   \renewcommand{\thestudentnumber}{#1}
+}
+
+\newcommand{\ClassificationNumber}[1]{
+  \renewcommand{\theClassificationNumber}{#1}
+}
+
+\newcommand{\ClassifiedClass}[1]{
+  \renewcommand{\theClassifiedClass}{#1}
+}
+
+\newcommand{\UDCNumber}[1]{
+  \renewcommand{\theUDCNumber}{#1}
+}
+
+\newcommand{\ProfessionalDegreeArea}[1]{
+  \renewcommand{\theProfessionalDegreeArea}{#1}
 }
 
 \newcommand{\thedateoral}{}
@@ -450,6 +472,10 @@
     of Electronic Science and Technology of China}
 }
 
+\newcommand{\ifpromaster}[2]{
+  \ifthenelse{\equal{\englishdegreename}{Professional Master}}{#1}{#2}
+}
+
 \DeclareOption{doctor}{
   \def\chinesedegreename{博士}
   \def\englishdegreename{Doctor}
@@ -501,6 +527,22 @@
 \newcommand{\thesisfigurelist}{
   \listoffigures
 }
+
+\pretocmd{\listoftables}{
+    \newpage
+  \fancyhf{}
+  \fancyhead[C]{\fontsize{10.5pt}{12.6pt}\selectfont\listtablename}
+  \fancyfoot[CE,CO]{\fontsize{9pt}{10.8pt}\selectfont\Roman{pseudopage}}
+  
+  \ifchinesebook{
+    \addtolength{\cfttabnumwidth}{12pt}
+    \renewcommand{\cfttabpresnum}{\tablename}
+  }{
+    \addtolength{\cfttabnumwidth}{32pt}
+    \renewcommand{\cfttabpresnum}{\tablename~}
+  }
+  \addtocontents{toc}{\protect\setcounter{tocdepth}{-1}}
+}{}{}
 
 \pretocmd{\listoftables}{
     \newpage
@@ -638,6 +680,23 @@
             & \\
     \cline{2-2}
   \end{tabular}\hspace*{\fill} \\[\baselineskip]
+  \ifpromaster{
+  \begin{tabular}{>{\bfseries\fontsize{16pt}{16pt}\selectfont}l
+      >{\centering\arraybackslash\bfseries\fontsize{16pt}{16pt}\selectfont}
+      p{3.77in}p{15pt}}
+    专业学位类别 & \zh@themajor &\\
+    \cline{2-2}
+    学\chinesespace\chinesespace\chinesespace\chinesespace 号 & \thestudentnumber & \\
+    \cline{2-2}
+    作\hspace{0.66em}者\hspace{0.66em}姓\hspace{0.67em}名 & \zh@theauthor &\\
+    \cline{2-2}
+    指\hspace{0.66em}导\hspace{0.66em}老\hspace{0.67em}师 & \zh@theadvisor &\\
+    \cline{2-2}
+    学\chinesespace\chinesespace\chinesespace\chinesespace 院 & \zh@theschool &\\
+    \cline{2-2}
+  \end{tabular}
+  }
+  {
   \begin{tabular}{>{\bfseries\fontsize{16pt}{16pt}\selectfont}l
       >{\centering\arraybackslash\bfseries\fontsize{16pt}{16pt}\selectfont}
       p{3.77in}p{15pt}}
@@ -652,21 +711,37 @@
     学\chinesespace\chinesespace 院 & \zh@theschool &\\
     \cline{2-2}
   \end{tabular}
+  }
 \end{center}
 
-\ifbachelor{}{\thetitlepage}
+\ifbachelor{}{\ifpromaster{\thetitlepageforpromaster}{\thetitlepage}}
 
 \newpage
 \setcounter{page}{1}
 \setlength{\extrarowheight}{2pt}
 }
 
+\newlength\myheight
+\newcommand\Mysavedprevdepth{}%
+\newcommand\UnderlineCentered[3]{%
+  \begin{adjustbox}{minipage=[t]{\dimexpr#1\relax},gstore totalheight=\myheight,margin=0pt}%
+    \centering\leavevmode#3\par\xdef\Mysavedprevdepth{\the\prevdepth}%
+  \end{adjustbox}%s
+  \hspace*{-\dimexpr#1\relax}%
+  \begin{adjustbox}{minipage=[t][\myheight]{\dimexpr#1\relax},margin=0pt}%
+    \vphantom{Eg}\lower\dimexpr#2\relax\hbox to\hsize{\leaders\hrule\hfill\kern0pt}\par
+    \kern-\dimexpr#2\relax
+    \xleaders\vbox to\baselineskip {\vfill\hbox{\lower\dimexpr#2\relax\hbox to\hsize{\leaders\hrule\hfill\kern0pt}}\kern-\dimexpr#2\relax}\vfill
+    \kern\Mysavedprevdepth
+  \end{adjustbox}%
+}%
+
 \newcommand{\thetitlepage}{
   \newpage
   \thispagestyle{empty}
 
-\noindent 分类号 \rule[-3pt]{2.5in}{0.5pt} 密级 \rule[-3pt]{2.5in}{0.5pt} \\[12bp]
-UDC\textsuperscript{ 注1} \rule[-3pt]{2.5in}{0.5pt} \\[12bp]
+\noindent 分类号 \hspace{0.5em}\UnderlineCentered{2.5in}{3pt}{\theClassificationNumber} 密级 \UnderlineCentered{2.5in}{3pt}{\theClassifiedClass} \\[12bp]
+UDC\textsuperscript{ 注1} \UnderlineCentered{2.5in}{3pt}{\theUDCNumber} \\[12bp]
 
 \begin{center}
   \fontsize{36pt}{36pt}\selectfont{
@@ -724,13 +799,13 @@ UDC\textsuperscript{ 注1} \rule[-3pt]{2.5in}{0.5pt} \\[12bp]
   \end{tabular} \\
   \begin{tabular}{>{\fontsize{12pt}{12pt}\selectfont}l
       >{\centering\arraybackslash\fontsize{14pt}{14pt}\heiti\selectfont}
-      p{2.29in}}
+      p{4.35in}}
       答辩委员会主席 & \\
     \cline{2-2}
   \end{tabular} \\
   \begin{tabular}{>{\fontsize{12pt}{12pt}\selectfont}l
       >{\centering\arraybackslash\fontsize{14pt}{14pt}\heiti\selectfont}
-      p{5.03in}}
+      p{5.01in}}
       评阅人 & \\
     \cline{2-2}
   \end{tabular}
@@ -764,9 +839,129 @@ UDC\textsuperscript{ 注1} \rule[-3pt]{2.5in}{0.5pt} \\[12bp]
 \cline{2-2}
 & \\
 \cline{2-2}
+Student ID: & \thestudentnumber \\
+\cline{2-2}
 Author: & \en@theauthor \\
 \cline{2-2}
+Supervisor: & \en@theadvisor \\
+\cline{2-2}
+School: & \en@theschool \\
+\cline{2-2}
+\end{tabular}
+}
+
+\newcommand{\thetitlepageforpromaster}{
+  \newpage
+  \thispagestyle{empty}
+
+\noindent 分类号 \hspace{0.5em}\UnderlineCentered{2.5in}{3pt}{\theClassificationNumber} 密级 \UnderlineCentered{2.5in}{3pt}{\theClassifiedClass} \\[12bp]
+UDC\textsuperscript{ 注1} \UnderlineCentered{2.5in}{3pt}{\theUDCNumber} \\[12bp]
+
+\begin{center}
+  \fontsize{36pt}{36pt}\selectfont{
+    学\chinesespace 位\chinesespace 论\chinesespace 文
+  } \\[48bp]
+
+  \fontsize{16pt}{16pt}\selectfont{\bfseries\zh@thetitle} \\
+  \vspace{-15pt}
+  \rule{5.9in}{.5pt} \\
+  \fontsize{12pt}{12pt}\selectfont（题名和副题名）\\[34bp]
+  \fontsize{16pt}{16pt}\selectfont{\bfseries\zh@theauthor} \\
+  \vspace{-15pt}
+  \rule{1.63in}{.5pt} \\
+  \fontsize{12pt}{12pt}\selectfont（作者姓名） \\[34bp]
+
+  \begin{tabular}{>{\fontsize{12pt}{12pt}\selectfont}l
+      >{\centering\arraybackslash\fontsize{16pt}{16pt}\selectfont}
+      p{4.45in}}
+      指导老师 & {\bfseries\zh@theadvisor} \\
+    \cline{2-2}
+      & {\bfseries 电子科技大学\chinesespace 成都} \\
+    \cline{2-2}
+    & \fontsize{12pt}{12pt}\selectfont（姓名、职称、单位名称）
+  \end{tabular}  \\[36bp]
+\end{center}
+
+  \noindent
+  \begin{tabular}{>{\fontsize{12pt}{12pt}\selectfont}l
+      >{\centering\arraybackslash\fontsize{14pt}{14pt}\bfseries\selectfont}
+      p{1.0in}
+      >{\fontsize{12pt}{12pt}\selectfont}l
+      >{\centering\arraybackslash\fontsize{14pt}{14pt}\bfseries\selectfont}
+      p{2.50in-2em}}
+      申请学位级别 & \chinesedegreename &
+      专业学位类别 & \zh@themajor \\
+    \cline{2-2}
+    \cline{4-4}
+  \end{tabular} \\
+  \begin{tabular}{>{\fontsize{12pt}{12pt}\selectfont}l
+      >{\centering\arraybackslash\fontsize{14pt}{14pt}\bfseries\selectfont}
+      p{4.53in}}
+      专业学位领域 & \theProfessionalDegreeArea \\
+    \cline{2-2}
+  \end{tabular} \\
+  \begin{tabular}{>{\fontsize{12pt}{12pt}\selectfont}l
+      >{\centering\arraybackslash\fontsize{14pt}{14pt}\bfseries\selectfont}
+      p{1.59in}
+      >{\fontsize{12pt}{12pt}\selectfont}l
+      >{\centering\arraybackslash\fontsize{14pt}{14pt}\bfseries\selectfont}
+      p{1.59in}}
+      提交论文日期 & \thedatesubmit &
+      论文答辩日期 & \thedateoral \\
+    \cline{2-2}
+    \cline{4-4}
+  \end{tabular} \\
+  \begin{tabular}{>{\fontsize{12pt}{12pt}\selectfont}l
+      >{\centering\arraybackslash\fontsize{14pt}{14pt}\bfseries\selectfont}
+      p{4.02in}}
+      学位授予单位和日期 & 电子科技大学\chinesespace{} \thedateconfer \\
+    \cline{2-2}
+  \end{tabular} \\
+  \begin{tabular}{>{\fontsize{12pt}{12pt}\selectfont}l
+      >{\centering\arraybackslash\fontsize{14pt}{14pt}\heiti\selectfont}
+      p{4.35in}}
+      答辩委员会主席 & \\
+    \cline{2-2}
+  \end{tabular} \\
+  \begin{tabular}{>{\fontsize{12pt}{12pt}\selectfont}l
+      >{\centering\arraybackslash\fontsize{14pt}{14pt}\heiti\selectfont}
+      p{5.01in}}
+      评阅人 & \\
+    \cline{2-2}
+  \end{tabular}
+
+\vspace{0.54in}
+\noindent
+\hspace{12pt}注1：注明《国际十进分类法UDC》的类号。
+
+\newpage
+\thispagestyle{empty}\null
+\par{\vspace{2.3cm}}
+\noindent
+\begin{minipage}[t][1.52cm][t]{\textwidth}
+  \fontsize{18pt}{20pt}\selectfont
+  \bfseries\centering\en@thetitle
+\end{minipage}
+\par{\vspace{6.3cm}}
+\noindent
+\begin{minipage}[t][1.52cm][t]{\textwidth}
+  \fontsize{15pt}{17pt}\selectfont
+  \centering\noindent
+  A \englishbooktitle{} Submitted to \\
+  University of Electronic Science and Technology of China
+\end{minipage}
+\par{\vspace{3.2cm}}
+\noindent
+\begin{tabular}{>{\fontsize{16pt}{16pt}\selectfont}r
+  >{\centering\arraybackslash\bfseries\fontsize{16pt}{16pt}\selectfont}
+  p{10.6cm}}
+  Discipline: & \multirow[t]{2}{*}{\en@themajor} \\
+\cline{2-2}
+& \\
+\cline{2-2}
 Student ID: & \thestudentnumber \\
+\cline{2-2}
+Author: & \en@theauthor \\
 \cline{2-2}
 Supervisor: & \en@theadvisor \\
 \cline{2-2}


### PR DESCRIPTION
    排版：
        专硕专用封面（增加\ProfessionalDegreeArea{}指令用于设置专业学位领域）
        英文封面学号姓名顺序
        页眉线磅数（修正为0.75磅）
        新增分类号（\ClassificationNumber{}）密级（\ClassifiedClass{}）和UDC号（\UDCNumber{}）设置功能
        修正封面“答辩委员会主席”等之后的下划线长度
    参考文献格式：
        英文名按新标修正为姓在前名缩写在后，且不加点
        专利和标准格式修正
        参考文献结束均为句点
        将部分难以获得的bib内容跳过并移除多余的标点