### PR TITLE
Fix author and supervisor formatting in English title page

### DIFF
--- a/thesis-uestc.cls
+++ b/thesis-uestc.cls
@@ -801,9 +801,9 @@ UDC\textsuperscript{ 注1} \underline{\makebox[2.4in]{\@udcnumber}} \\[0bp]
 \cline{2-2}
 & \\
 \cline{2-2}
-Author: & \en@theauthor \\
-\cline{2-2}
 Student ID: & \thestudentnumber \\
+\cline{2-2}
+Author: & \en@theauthor \\
 \cline{2-2}
 Supervisor: & \en@theadvisor \\
 \cline{2-2}


### PR DESCRIPTION
英语扉页的学号应该在作者和学科之间

<img width="1408" height="689" alt="image" src="https://github.com/user-attachments/assets/2bd007a6-329f-4f01-aeb3-bb30f2600d46" />


https://gr.uestc.edu.cn/attached/papers/257/202410/%E7%94%B5%E5%AD%90%E7%A7%91%E6%8A%80%E5%A4%A7%E5%AD%A6%E7%A0%94%E7%A9%B6%E7%94%9F%E5%AD%A6%E4%BD%8D%E8%AE%BA%E6%96%87%E5%B0%81%E9%9D%A2%E5%8F%8A%E6%89%89%E9%A1%B5%20-%20%E9%80%82%E7%94%A8%E4%BA%8E%E5%AD%A6%E6%9C%AF%E5%AD%A6%E4%BD%8D%E5%8D%9A%E5%A3%AB_081704331879.docx

